### PR TITLE
Improve flake and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ complex deployments.
 
 With this setup your system has local control over secret decryption while
 keeping the encrypted data in version control.
-
 ### Using Vault as a secrets provider
 
 `sops-nix` can pull decryption keys from Vault. Configure the Vault

--- a/README.md
+++ b/README.md
@@ -1,1 +1,154 @@
 # nix-gitops-flake
+
+This repository contains a small **Rust-based GitOps agent** and example
+configuration. The agent periodically pulls a Nix flake from an upstream
+repository and applies it to your system. A key feature is local secrets
+management using `age-nix`, so you can keep encrypted files under version
+control without relying on an external provider. The example is intended for a
+single machine but can be extended to work with `sops-nix` and Vault for more
+complex deployments.
+
+## Using age-nix
+
+1. **Generate a key pair**
+   Run `age-keygen -o /etc/ssh/age.key` on the target machine. The command
+   prints the public key which you will use to encrypt your secrets.
+
+2. **Add age-nix to your flake**
+   Include the `age-nix` and `sops-nix` modules and enable them in your
+   configuration:
+
+   ```nix
+   {
+     inputs = {
+       age-nix.url = "github:Mic92/age.nix";
+       sops-nix.url = "github:Mic92/sops-nix";
+       nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+     };
+
+     outputs = { self, nixpkgs, age-nix, sops-nix, ... }:
+       let
+         system = "x86_64-linux";
+         pkgs = import nixpkgs { inherit system; };
+       in
+       {
+         nixosConfigurations.myhost = pkgs.nixosSystem {
+           system = system;
+           modules = [
+             age-nix.nixosModules.default
+             sops-nix.nixosModules.sops
+             ./modules/gitops.nix
+           ];
+         };
+       };
+   }
+   ```
+
+3. **Reference the key**
+   Configure age-nix and sops-nix to read the private key generated above:
+
+   ```nix
+   { config, ... }:
+   {
+     age.identityPaths = [ "/etc/ssh/age.key" ];
+     sops.age.keyFile = "/etc/ssh/age.key";
+   }
+   ```
+
+4. **Encrypt your secrets**
+   Use `sops` with the printed public key:
+
+   ```bash
+   sops --age <public-key> secrets.yaml
+   ```
+
+   Commit the resulting `secrets.yaml` file to your repository. When your
+   GitOps service runs, `age-nix` provides the private key so `sops` can
+   decrypt the file locally and apply the secrets.
+
+With this setup your system has local control over secret decryption while
+keeping the encrypted data in version control.
+
+### Using Vault as a secrets provider
+
+`sops-nix` can pull decryption keys from Vault. Configure the Vault
+connection and authentication method and `sops` will fetch the key at
+runtime:
+
+```nix
+{ config, ... }:
+{
+  sops.vault = {
+    enable = true;
+    address = "https://vault.example.com";
+    tokenFile = "/etc/vault-token"; # or use approle parameters
+  };
+}
+```
+
+The token file or approle credentials must be available on the machine so the
+GitOps service can decrypt secrets when it runs.
+
+## GitOps service module
+
+This flake also exposes a helper script and a NixOS module so you can
+install a service that regularly pulls an upstream repository and applies
+its flake.
+
+1. **Add the flake as an input**
+
+   ```nix
+   inputs.gitops.url = "github:yourname/nix-gitops-flake";
+   ```
+
+2. **Enable the module**
+
+   ```nix
+   {
+     imports = [ inputs.gitops.nixosModules.gitops ];
+
+     services.gitops = {
+       enable = true;
+       repository = "https://github.com/myorg/infra.git";
+       ref = "main";            # or a tag
+       frequency = "30m";       # how often to check for changes
+     };
+   }
+   ```
+
+The module installs a `systemd` timer and service called `gitops-sync`.
+It runs the bundled `gitops-sync` script which clones the repository and
+executes `nixos-rebuild` with the checked-out flake. Secrets managed
+with `sops-nix`, `age-nix`, or Vault become available during the rebuild
+so sensitive data stays encrypted in your repo.
+
+You can also install the helper script directly using:
+
+```bash
+nix profile install github:yourname/nix-gitops-flake#gitops-sync
+```
+
+This makes it easy to experiment locally or run the sync manually.
+
+### Installing via overlay
+
+The flake provides an overlay so you can access the package through
+`nixpkgs` without using `nix profile`:
+
+```nix
+{
+  inputs.gitops.url = "github:yourname/nix-gitops-flake";
+
+  outputs = { self, nixpkgs, gitops, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; overlays = [ gitops.overlays.default ]; };
+    in
+    {
+      packages.x86_64-linux.gitops-sync = pkgs.gitops-sync;
+    };
+}
+```
+
+This overlay can later be submitted to `nixpkgs` so the package becomes
+available as `pkgs.gitops-sync` for all users.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Example GitOps flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      overlay = final: prev: {
+        gitops-sync = final.writeShellApplication {
+          name = "gitops-sync";
+          runtimeInputs = [ final.git final.nixos-rebuild ];
+          text = builtins.readFile ./scripts/gitops-sync;
+        };
+      };
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ overlay ]; };
+      in
+      rec {
+        packages.gitops-sync = pkgs.gitops-sync;
+        defaultPackage = packages.gitops-sync;
+      }
+    ) // {
+      overlays.default = overlay;
+      nixosModules.gitops = import ./modules/gitops.nix;
+    };
+}

--- a/modules/gitops.nix
+++ b/modules/gitops.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.gitops;
+  script = pkgs.gitops-sync;
+in
+{
+  options.services.gitops = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable GitOps synchronization";
+    };
+
+    repository = mkOption {
+      type = types.str;
+      description = "URL of the upstream Git repository";
+    };
+
+    ref = mkOption {
+      type = types.str;
+      default = "main";
+      description = "Branch or tag to deploy";
+    };
+
+    frequency = mkOption {
+      type = types.str;
+      default = "15m";
+      description = "Run interval for the sync timer";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.gitops-sync = {
+      description = "GitOps sync service";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = ''${script}/bin/gitops-sync '${cfg.repository}' '${cfg.ref}' '';
+      };
+    };
+
+    systemd.timers.gitops-sync = {
+      wantedBy = [ "timers.target" ];
+      timerConfig.OnUnitActiveSec = cfg.frequency;
+    };
+  };
+}

--- a/scripts/gitops-sync
+++ b/scripts/gitops-sync
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$1"
+ref="$2"
+workdir=/var/lib/gitops
+
+if [ ! -d "$workdir" ]; then
+  git clone "$repo" "$workdir"
+else
+  git -C "$workdir" fetch origin
+fi
+
+git -C "$workdir" fetch --tags origin
+# Try to track the branch if it exists; otherwise checkout the tag
+if git -C "$workdir" rev-parse --verify "origin/$ref" >/dev/null 2>&1; then
+  git -C "$workdir" checkout -B "$ref" "origin/$ref"
+else
+  git -C "$workdir" checkout "$ref"
+fi
+
+nixos-rebuild switch --flake "$workdir#$(hostname)"
+


### PR DESCRIPTION
## Summary
- update to NixOS 25.05 and add overlay output
- document how to use the overlay and fetch Vault secrets
- handle git tags and branches in gitops-sync script

## Testing
- `git status --short`
- `nix flake show --impure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854cf3c637c8328bd8096729d74c024